### PR TITLE
fix: extra BOM write to file

### DIFF
--- a/Lib/WebViewToo.ahk
+++ b/Lib/WebViewToo.ahk
@@ -718,7 +718,6 @@ class WebViewCtrl extends Gui.Custom {
         ResourceSize := DllCall("SizeofResource", "Ptr", Module, "Ptr", Resource)
         ResourceData := DllCall("LoadResource", "Ptr", Module, "Ptr", Resource, "Ptr")
         ConvertedData := DllCall("LockResource", "Ptr", ResourceData, "Ptr")
-        TextData := StrGet(ConvertedData, ResourceSize, "UTF-8")
 
         if (!DirExist(DestinationDir "\" OutDir)) {
             DirCreate(DestinationDir "\" OutDir)
@@ -735,7 +734,7 @@ class WebViewCtrl extends Gui.Custom {
         }
 
         if (!FileExist(DestinationDir "\" ResourceName)) {
-            TempFile := FileOpen(DestinationDir "\" ResourceName, "w")
+            TempFile := FileOpen(DestinationDir "\" ResourceName, "w", "CP0")
             TempFile.RawWrite(ConvertedData, ResourceSize)
             TempFile.Close()
             FileSetAttrib("+HR", DestinationDir "\" OutDir)
@@ -1222,4 +1221,5 @@ class WebViewCtrl extends Gui.Custom {
     ServerCertificateErrorDetected(Handler) => this.wv.add_ServerCertificateErrorDetected(Handler)
     FaviconChanged(Handler) => this.wv.add_FaviconChanged(Handler)
     LaunchingExternalUriScheme(Handler) => this.wv.add_LaunchingExternalUriScheme(Handler)
+
 }


### PR DESCRIPTION
In AutoHotkey v2, when opening or creating files using “w” (Write) mode, the default encoding is UTF-8 (with BOM). When you execute FileOpen, AHK silently writes a three-byte BOM at the very beginning of the file. Subsequent RawWrite operations write the correct binary data, but they append it after the BOM.

Explicitly specifying the encoding as “CP0” will completely prevent AHK from automatically writing BOM markers.